### PR TITLE
removing update from the git recipe deploy:setup action so that before a...

### DIFF
--- a/lib/capistrano-deploy/git.rb
+++ b/lib/capistrano-deploy/git.rb
@@ -19,7 +19,6 @@ module CapistranoDeploy
           desc 'Setup'
           task :setup, :except => {:no_release => true} do
             run "mkdir -p `dirname #{deploy_to}` && git clone --no-checkout #{repository} #{deploy_to}"
-            update
           end
 
           desc 'Update the deployed code'


### PR DESCRIPTION
...nd after hooks can be placed between the two actions
