### PR TITLE
Fetch env from git repo

### DIFF
--- a/lib/capistrano-deploy/campfire.rb
+++ b/lib/capistrano-deploy/campfire.rb
@@ -8,7 +8,7 @@ module CapistranoDeploy
           desc 'Set notification in campfire for deployment start'
           task :start_msg do
             campy = Campy::Room.new(account: campfire_account, token: campfire_token, room_id: campfire_room_id)
-            campy.speak "#{campfire_speaker.upcase} is starting deploy of '#{app_name.upcase}' from branch '#{branch}' to #{current_stage.upcase}"
+            campy.speak "#{campfire_speaker.chomp} is starting deploy of '#{app_name.upcase}' from branch '#{branch}' to #{current_stage.upcase}"
           end
 
           desc 'Set notification in campfire for deployment end'

--- a/lib/capistrano-deploy/environment.rb
+++ b/lib/capistrano-deploy/environment.rb
@@ -10,20 +10,18 @@ module CapistranoDeploy
           namespace :servers do
             desc "Copy ENV file from remote git repository to your staging/production servers"
             task :fetch_config, :roles => :app, :except => {:no_release => true} do
+
+              if /^y/i =~ Capistrano::CLI.ui.ask("Do you wish to override the existing #{environment_file} file (y/n)? ")
+
               path_to_new_env = File.join deploy_to, "tmp", "env_config", app_name, ".env.#{current_stage}"
               path_to_old_env = File.join deploy_to, environment_file
 
               run "rm -rf #{deploy_to}/tmp/env_config && git clone -n #{environment_repository} --depth 1 #{deploy_to}/tmp/env_config"
               run "cd #{deploy_to}/tmp/env_config && git checkout HEAD #{app_name}/.env.#{current_stage}"
-
-              lines_changed = capture("diff #{path_to_new_env} #{path_to_old_env} | wc -l").chomp.to_i
-
-              if lines_changed > 0 && /^y/i =~ Capistrano::CLI.ui.ask("Do you wish to override the existing #{environment_file} file (y/n)? ")
-                run "cp #{path_to_new_env}  #{path_to_old_env}"
+              run "cp #{path_to_new_env}  #{path_to_old_env}"
               else
-                puts "No config changes found (or you said 'No')"
+                puts "Config not changed"
               end
-
             end
 
           end

--- a/lib/capistrano-deploy/environment.rb
+++ b/lib/capistrano-deploy/environment.rb
@@ -3,17 +3,20 @@ module CapistranoDeploy
     def self.load_into(configuration)
       configuration.load do
 
+        set(:environment_file) { ".env" }
+
         namespace :environment do
           desc "Copy ENV file from remote git repository to your staging/production servers"
           task :fetch_config, :roles => :app, :except => {:no_release => true} do
             path_to_new_env = File.join deploy_to, "tmp", "env_config", app_name, ".env.#{current_stage}"
-            path_to_old_env = File.join deploy_to, ".env.fake"
+            path_to_old_env = File.join deploy_to, environment_file
 
             run "rm -rf #{deploy_to}/tmp/env_config && git clone -n #{environment_repository} --depth 1 #{deploy_to}/tmp/env_config"
-            run "cd #{deploy_to}/tmp/env_config && git checkout HEAD #{path_to_new_env}"
+            run "cd #{deploy_to}/tmp/env_config && git checkout HEAD #{app_name}/.env.#{current_stage}"
 
-            changed = run "diff #{path_to_new_env} #{path_to_new_env}"
-            if changed && /^y/i =~ Capistrano::CLI.ui.ask("Do you wish to override the existing .env file (y/n)? ")
+            lines_changed = capture("diff #{path_to_new_env} #{path_to_old_env} | wc -l").chomp.to_i
+
+            if lines_changed > 0 && /^y/i =~ Capistrano::CLI.ui.ask("Do you wish to override the existing .env file (y/n)? ")
               run "cp #{path_to_new_env}  #{path_to_old_env}"
             end
 

--- a/lib/capistrano-deploy/environment.rb
+++ b/lib/capistrano-deploy/environment.rb
@@ -1,0 +1,32 @@
+module CapistranoDeploy
+  module Environment
+    def self.load_into(configuration)
+      configuration.load do
+
+        namespace :environment do
+          desc "Copy ENV file from remote git repository to your staging/production servers"
+          task :fetch_config, :roles => :app, :except => {:no_release => true} do
+            path_to_new_env = File.join deploy_to, "tmp", "env_config", app_name, ".env.#{current_stage}"
+            path_to_old_env = File.join deploy_to, ".env.fake"
+
+            run "rm -rf #{deploy_to}/tmp/env_config && git clone -n #{environment_repository} --depth 1 #{deploy_to}/tmp/env_config"
+            run "cd #{deploy_to}/tmp/env_config && git checkout HEAD #{path_to_new_env}"
+
+            changed = run "diff #{path_to_new_env} #{path_to_new_env}"
+            if changed && /^y/i =~ Capistrano::CLI.ui.ask("Do you wish to override the existing .env file (y/n)? ")
+              run "cp #{path_to_new_env}  #{path_to_old_env}"
+            end
+
+          end
+
+          desc "Fetch ENV file from remote git repository to your local machine"
+          task :fetch_config_locally do
+            raise "Not yet implemented"
+          end
+        end
+
+        after 'deploy:setup', 'environment:fetch_config'
+      end
+    end
+  end
+end

--- a/lib/capistrano-deploy/environment.rb
+++ b/lib/capistrano-deploy/environment.rb
@@ -6,29 +6,39 @@ module CapistranoDeploy
         set(:environment_file) { ".env" }
 
         namespace :environment do
-          desc "Copy ENV file from remote git repository to your staging/production servers"
-          task :fetch_config, :roles => :app, :except => {:no_release => true} do
-            path_to_new_env = File.join deploy_to, "tmp", "env_config", app_name, ".env.#{current_stage}"
-            path_to_old_env = File.join deploy_to, environment_file
 
-            run "rm -rf #{deploy_to}/tmp/env_config && git clone -n #{environment_repository} --depth 1 #{deploy_to}/tmp/env_config"
-            run "cd #{deploy_to}/tmp/env_config && git checkout HEAD #{app_name}/.env.#{current_stage}"
+          namespace :servers do
+            desc "Copy ENV file from remote git repository to your staging/production servers"
+            task :fetch_config, :roles => :app, :except => {:no_release => true} do
+              path_to_new_env = File.join deploy_to, "tmp", "env_config", app_name, ".env.#{current_stage}"
+              path_to_old_env = File.join deploy_to, environment_file
 
-            lines_changed = capture("diff #{path_to_new_env} #{path_to_old_env} | wc -l").chomp.to_i
+              run "rm -rf #{deploy_to}/tmp/env_config && git clone -n #{environment_repository} --depth 1 #{deploy_to}/tmp/env_config"
+              run "cd #{deploy_to}/tmp/env_config && git checkout HEAD #{app_name}/.env.#{current_stage}"
 
-            if lines_changed > 0 && /^y/i =~ Capistrano::CLI.ui.ask("Do you wish to override the existing .env file (y/n)? ")
-              run "cp #{path_to_new_env}  #{path_to_old_env}"
+              lines_changed = capture("diff #{path_to_new_env} #{path_to_old_env} | wc -l").chomp.to_i
+
+              if lines_changed > 0 && /^y/i =~ Capistrano::CLI.ui.ask("Do you wish to override the existing #{environment_file} file (y/n)? ")
+                run "cp #{path_to_new_env}  #{path_to_old_env}"
+              else
+                puts "No config changes found (or you said 'No')"
+              end
+
             end
 
           end
 
-          desc "Fetch ENV file from remote git repository to your local machine"
-          task :fetch_config_locally do
-            raise "Not yet implemented"
+          namespace :local do
+            desc "Fetch ENV file from remote git repository to your local machine"
+            task :fetch_config do
+              raise "Not yet implemented"
+            end
           end
+
+          after 'deploy:setup', 'environment:servers:fetch_config'
+
         end
 
-        after 'deploy:setup', 'environment:fetch_config'
       end
     end
   end


### PR DESCRIPTION
Add the following to Capistrano (`Capfile`): 

```
set :environment_repository, 'git@git.example.com:path/to/your_repo.git'

# This line is optional - if you're using '.my_own_file' instead of '.env'
set :environment_file, '.my_own_file'
```

Note that you may have to setup key forwarding on your local machine, and add your keys to your Git host (i.e. add your keys to your github.com account - or whomever you use for a git host)
