### PR TITLE
Verify the host's keys

### DIFF
--- a/lib/capistrano-deploy/environment.rb
+++ b/lib/capistrano-deploy/environment.rb
@@ -38,7 +38,7 @@ module CapistranoDeploy
           end
 
           after 'deploy:setup', 'environment:servers:verify'
-          after 'environment:servers:verfiy', 'environment:servers:fetch_config'
+          after 'environment:servers:verify', 'environment:servers:fetch_config'
 
         end
 

--- a/lib/capistrano-deploy/environment.rb
+++ b/lib/capistrano-deploy/environment.rb
@@ -24,6 +24,10 @@ module CapistranoDeploy
               end
             end
 
+            task :verify do
+              run "ssh-keyscan #{environment_host} | tee --append $HOME/.ssh/known_hosts"
+            end
+
           end
 
           namespace :local do
@@ -33,7 +37,8 @@ module CapistranoDeploy
             end
           end
 
-          after 'deploy:setup', 'environment:servers:fetch_config'
+          after 'deploy:setup', 'environment:servers:verify'
+          after 'environment:servers:verfiy', 'environment:servers:fetch_config'
 
         end
 


### PR DESCRIPTION
- Grab the public key from the Git server
  that hosts the env repository and add it
  to the user's known_hosts file so the
  git clone in environment:servers:fetch_config
  succeeds
