### PR TITLE
Our unicorn config requires dotenv

### DIFF
--- a/capistrano-deploy.gemspec
+++ b/capistrano-deploy.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency('capistrano', '~> 2.9')
   s.add_dependency('campy', '~> 1.0.0')
+  s.add_dependency('dotenv', '~> 0.9.0')
 end

--- a/capistrano-deploy.gemspec
+++ b/capistrano-deploy.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency('capistrano', '~> 2.9')
   s.add_dependency('campy', '~> 1.0.0')
-  s.add_dependency('dotenv', '~> 0.9.0')
+  s.add_dependency('dotenv', '~> 0.8.0')
 end


### PR DESCRIPTION
- In each project we have a unicorn config
  that does a Dotenv.load to reload any .env file
  changes. If the project using that config does not have the
  dotenv gem the unicorn:reexec command will not reload
  the .env
- setting to an older version 0.9 instead of 0.10 because
  our projects are using snapshot which only is compatible
  with dotenv (0.9.0)
