### PR TITLE
Fix deploy script for campfire message

### DIFF
--- a/lib/capistrano-deploy/campfire.rb
+++ b/lib/capistrano-deploy/campfire.rb
@@ -20,7 +20,7 @@ module CapistranoDeploy
         end
 
         before 'deploy:update', 'campfire:start_msg'
-        after 'deploy:update', 'campfire:end_msg'
+        after 'unicorn:reexec', 'campfire:end_msg'
       end
     end
   end


### PR DESCRIPTION
- Move campfire finish deploy message to
  be execute after unicorn:reexec. this will
  be executed after deloyment is finish.
  ![screen shot 2014-03-25 at 10 07 14 am](https://f.cloud.github.com/assets/1048714/2514524/b9f36e34-b439-11e3-835d-30b7ebc835fa.png)
