### PR TITLE
Lh 3624

### DIFF
--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -6,7 +6,7 @@ module CapistranoDeploy
         namespace :newrelic do
 
           task :notice_deployment do
-            run "curl -H 'x-api-key:eecea6ff70c4296b9dc0d8ff1761c8354e4a41e9d559404' -d 'deployment[app_name]=Your Account' https://api.newrelic.com/deployments.xml"
+            run "curl -H 'x-api-key:eecea6ff70c4296b9dc0d8ff1761c8354e4a41e9d559404' -d 'deployment[app_name]=#{app_name}' https://api.newrelic.com/deployments.xml"
           end
         end
 

--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -5,15 +5,15 @@ module CapistranoDeploy
       configuration.load do
 
         set(:api_key) { ENV['NEW_RELIC_API_KEY'] }
-        set(:app_name) { ENV['NEW_RELIC_APP_NAME'] }
-        set(:user) { capture("users").chomp }
+        set(:new_relic_app_name) { ENV['NEW_RELIC_APP_NAME'] }
+        set(:new_relic_user) { capture("users").chomp }
         set(:current_revision) { capture("cd #{deploy_to} && git rev-parse HEAD").chomp }
         set(:link) { "https://api.newrelic.com/deployments.xml" }
 
         namespace :newrelic do
 
           task :notice_deployment do
-            run "curl -H '#{api_key}' -d 'deployment[app_name]=#{app_name}' -d 'deployment[revision]=#{current_revision}' -d 'deployment[user]=#{user}' #{link}"
+            run "curl -H '#{api_key}' -d 'deployment[app_name]=#{new_relic_app_name}' -d 'deployment[revision]=#{current_revision}' -d 'deployment[user]=#{new_relic_user}' #{link}"
           end
         end
 

--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -3,10 +3,15 @@ module CapistranoDeploy
   module Newrelic
     def self.load_into(configuration)
       configuration.load do
+
+        set(:current_revision) { capture("cd #{deploy_to} && git rev-parse HEAD").chomp }
+        set(:api_key) { ENV['NEW_RELIC_API_KEY'] }
+        set(:link) { "https://api.newrelic.com/deployments.xml" }
+
         namespace :newrelic do
 
           task :notice_deployment do
-            run "curl -H 'x-api-key:eecea6ff70c4296b9dc0d8ff1761c8354e4a41e9d559404' -d 'deployment[app_name]=#{app_name}' https://api.newrelic.com/deployments.xml"
+            run "curl -H '#{api_key}' -d 'deployment[app_name]=#{app_name}' -d 'deployment[revision]=#{current_revision}' #{link}"
           end
         end
 

--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -6,8 +6,7 @@ module CapistranoDeploy
         namespace :newrelic do
 
           task :notice_deployment do
-            #run "curl -H 'eecea6ff70c4296b9dc0d8ff1761c8354e4a41e9d559404:eecea6ff70c4296b9dc0d8ff1761c8354e4a41e9d559404' -d 'deployment[app_name]=Your Account' https://api.newrelic.com/deployments.xml"
-            run "curl -H 'eecea6ff70c4296b9dc0d8ff1761c8354e4a41e9d559404:eecea6ff70c4296b9dc0d8ff1761c8354e4a41e9d559404' -d 'deployment[application_id]=2936733' -d 'deployment[description]=This deployment was sent using curl' -d 'deployment[revision]=1242' -d 'deployment[changelog]=many hands make light work' -d 'deployment[user]=Ruben Estevez' https://api.newrelic.com/deployments.xml"
+            run "curl -H 'x-api-key:eecea6ff70c4296b9dc0d8ff1761c8354e4a41e9d559404' -d 'deployment[app_name]=Your Account' https://api.newrelic.com/deployments.xml"
           end
         end
 

--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -6,7 +6,7 @@ module CapistranoDeploy
 
         set(:api_key) { ENV['NEW_RELIC_API_KEY'] }
         set(:new_relic_app_name) { ENV['NEW_RELIC_APP_NAME'] }
-        set(:new_relic_user) { capture("users").chomp }
+        set(:new_relic_user) { (%x(users)).chomp }
         set(:current_revision) { capture("cd #{deploy_to} && git rev-parse HEAD").chomp }
         set(:link) { "https://api.newrelic.com/deployments.xml" }
 

--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -1,0 +1,18 @@
+require 'new_relic/recipes'
+module CapistranoDeploy
+  module Newrelic
+    def self.load_into(configuration)
+      configuration.load do
+        namespace :newrelic do
+
+          task :notice_deployment do
+            #run "curl -H 'eecea6ff70c4296b9dc0d8ff1761c8354e4a41e9d559404:eecea6ff70c4296b9dc0d8ff1761c8354e4a41e9d559404' -d 'deployment[app_name]=Your Account' https://api.newrelic.com/deployments.xml"
+            run "curl -H 'eecea6ff70c4296b9dc0d8ff1761c8354e4a41e9d559404:eecea6ff70c4296b9dc0d8ff1761c8354e4a41e9d559404' -d 'deployment[application_id]=2936733' -d 'deployment[description]=This deployment was sent using curl' -d 'deployment[revision]=1242' -d 'deployment[changelog]=many hands make light work' -d 'deployment[user]=Ruben Estevez' https://api.newrelic.com/deployments.xml"
+          end
+        end
+
+        after 'unicorn:reexec', 'newrelic:notice_deployment'
+      end
+    end
+  end
+end

--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -11,9 +11,10 @@ module CapistranoDeploy
         namespace :newrelic do
 
           task :notice_deployment do
-            run "curl -H '#{new_relic_api_key}' -d 'deployment[app_name]=#{new_relic_app_name}'
-                -d 'deployment[revision]=#{current_revision}' -d 'deployment[user]=#{new_relic_user}'
-                -d 'deployment[description]=#{current_stage}' #{link}"
+            run "curl -H '#{new_relic_api_key}'
+                -d 'deployment[app_name]=#{new_relic_app_name}'
+                -d 'deployment[revision]=#{current_revision}'
+                -d 'deployment[user]=#{new_relic_user}' #{link}"
           end
         end
 

--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -11,7 +11,9 @@ module CapistranoDeploy
         namespace :newrelic do
 
           task :notice_deployment do
-            run "curl -H '#{new_relic_api_key}' -d 'deployment[app_name]=#{new_relic_app_name}' -d 'deployment[revision]=#{current_revision}' -d 'deployment[user]=#{new_relic_user}' #{link}"
+            run "curl -H '#{new_relic_api_key}' -d 'deployment[app_name]=#{new_relic_app_name}'
+                -d 'deployment[revision]=#{current_revision}' -d 'deployment[user]=#{new_relic_user}'
+                -d deployment[description]='#{current_stage}' #{link}"
           end
         end
 

--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -4,20 +4,17 @@ module CapistranoDeploy
     def self.load_into(configuration)
       configuration.load do
 
-        set(:api_key) { ENV['NEW_RELIC_API_KEY'] }
-        set(:new_relic_app_name) { ENV['NEW_RELIC_APP_NAME'] }
-        set(:new_relic_user) { (%x(users)).chomp }
+        set(:new_relic_user) { (%x(git config user.name)).chomp }
         set(:current_revision) { capture("cd #{deploy_to} && git rev-parse HEAD").chomp }
         set(:link) { "https://api.newrelic.com/deployments.xml" }
 
         namespace :newrelic do
 
           task :notice_deployment do
-            run "curl -H '#{api_key}' -d 'deployment[app_name]=#{new_relic_app_name}' -d 'deployment[revision]=#{current_revision}' -d 'deployment[user]=#{new_relic_user}' #{link}"
+            run "curl -H '#{new_relic_api_key}' -d 'deployment[app_name]=#{new_relic_app_name}' -d 'deployment[revision]=#{current_revision}' -d 'deployment[user]=#{new_relic_user}' #{link}"
           end
         end
 
-        after 'unicorn:reexec', 'newrelic:notice_deployment'
       end
     end
   end

--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -13,7 +13,7 @@ module CapistranoDeploy
           task :notice_deployment do
             run "curl -H '#{new_relic_api_key}' -d 'deployment[app_name]=#{new_relic_app_name}'
                 -d 'deployment[revision]=#{current_revision}' -d 'deployment[user]=#{new_relic_user}'
-                -d deployment[description]='#{current_stage}' #{link}"
+                -d 'deployment[description]=#{current_stage}' #{link}"
           end
         end
 

--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -4,14 +4,16 @@ module CapistranoDeploy
     def self.load_into(configuration)
       configuration.load do
 
-        set(:current_revision) { capture("cd #{deploy_to} && git rev-parse HEAD").chomp }
         set(:api_key) { ENV['NEW_RELIC_API_KEY'] }
+        set(:app_name) { ENV['NEW_RELIC_APP_NAME'] }
+        set(:user) { capture("users").chomp }
+        set(:current_revision) { capture("cd #{deploy_to} && git rev-parse HEAD").chomp }
         set(:link) { "https://api.newrelic.com/deployments.xml" }
 
         namespace :newrelic do
 
           task :notice_deployment do
-            run "curl -H '#{api_key}' -d 'deployment[app_name]=#{app_name}' -d 'deployment[revision]=#{current_revision}' #{link}"
+            run "curl -H '#{api_key}' -d 'deployment[app_name]=#{app_name}' -d 'deployment[revision]=#{current_revision}' -d 'deployment[user]=#{user}' #{link}"
           end
         end
 


### PR DESCRIPTION
Added newrelic deployment hook

extra parameters can be sent:
deployment[app_name]            The name of the application, found in the newrelic.yml file
deployment[application_id]  The ID # of the application
deployment[description]     Text annotation for the deployment — notes
deployment[revision]            The revision number from your source control system (SVN, git, etc.)
deployment[changelog]           A list of changes for this deployment
deployment[user]                    The name of the user/process that triggered this deployment

In order for the Hook to work you have to add the :newrelic recipe to the user_recipes on the Capfiles of the projects.

This was tested using my_ama pointing the gem to the github branch
    gem 'capistrano-deploy', github: 'amaabca/capistrano-deploy', branch: 'LH-3624'
there is a branch on my_ama (LH-3624) that you can use for testing.
