### PR TITLE
Suppress curl data transfer spam in deploy output.

### DIFF
--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -11,7 +11,7 @@ module CapistranoDeploy
         namespace :newrelic do
 
           task :notice_deployment do
-            run "curl -H '#{new_relic_api_key}'
+            run "curl -sH '#{new_relic_api_key}'
                 -d 'deployment[app_name]=#{new_relic_app_name}'
                 -d 'deployment[revision]=#{current_revision}'
                 -d 'deployment[user]=#{new_relic_user}' #{link}"


### PR DESCRIPTION
- Don't need to see bytes transferred from curl output.
- They show up one character per line, with red error labels too. Scary!
