### PR TITLE
New relic notification only for primary production servers

### DIFF
--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -4,17 +4,20 @@ module CapistranoDeploy
     def self.load_into(configuration)
       configuration.load do
 
+        set(:new_relic_stages) { %w(production) }
         set(:new_relic_user) { (%x(git config user.name)).chomp }
         set(:current_revision) { capture("cd #{deploy_to} && git rev-parse HEAD").chomp }
         set(:link) { "https://api.newrelic.com/deployments.xml" }
 
         namespace :newrelic do
 
-          task :notice_deployment, roles: :notification do
+          task :notice_deployment, roles: :notification, only: { primary: true } do
+            if new_relic_stages.include? current_stage
             run "curl -sH '#{new_relic_api_key}'
                 -d 'deployment[app_name]=#{new_relic_app_name}'
                 -d 'deployment[revision]=#{current_revision}'
                 -d 'deployment[user]=#{new_relic_user}' #{link}"
+            end
           end
         end
 

--- a/lib/capistrano-deploy/newrelic.rb
+++ b/lib/capistrano-deploy/newrelic.rb
@@ -13,11 +13,11 @@ module CapistranoDeploy
 
           task :notice_deployment, roles: :notification, only: { primary: true } do
             if new_relic_stages.include? current_stage
-            run "curl -sH '#{new_relic_api_key}'
-                -d 'deployment[app_name]=#{new_relic_app_name}'
-                -d 'deployment[revision]=#{current_revision}'
-                -d 'deployment[user]=#{new_relic_user}' #{link}"
-            end
+              run "curl -sH '#{new_relic_api_key}'
+                  -d 'deployment[app_name]=#{new_relic_app_name}'
+                  -d 'deployment[revision]=#{current_revision}'
+                  -d 'deployment[user]=#{new_relic_user}' #{link}"
+              end
           end
         end
 


### PR DESCRIPTION
- Only run notification task in the production stage - and only on the primary server for the `:notification` role
- Previously this would fail in staging (but we never noticed any issues because new `relic:notice_deployment` was always the last task to run
